### PR TITLE
Add Discord group editing API

### DIFF
--- a/middlewares/validators/discordactions.js
+++ b/middlewares/validators/discordactions.js
@@ -15,6 +15,21 @@ const validateGroupRoleBody = async (req, res, next) => {
     res.boom.badRequest(error.details[0].message);
   }
 };
+
+const validateGroupRoleUpdateBody = async (req, res, next) => {
+  const schema = Joi.object({
+    rolename: Joi.string().trim(),
+    description: Joi.string().trim(),
+  }).or("rolename", "description");
+
+  try {
+    await schema.validateAsync(req.body);
+    next();
+  } catch (error) {
+    logger.error(`Error validating updateGroupRole payload : ${error}`);
+    res.boom.badRequest(error.details[0].message);
+  }
+};
 const validateMemberRoleBody = async (req, res, next) => {
   const schema = Joi.object({
     userid: Joi.string().trim().required(),
@@ -66,4 +81,5 @@ module.exports = {
   validateMemberRoleBody,
   validateLazyLoadingParams,
   validateUpdateUsersNicknameStatusBody,
+  validateGroupRoleUpdateBody,
 };

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -15,6 +15,7 @@ const {
   syncDiscordGroupRolesInFirestore,
   setRoleToUsersWith31DaysPlusOnboarding,
   deleteGroupRole,
+  updateGroupRoleDetails,
   getPaginatedAllGroupRoles,
 } = require("../controllers/discordactions");
 const {
@@ -22,6 +23,7 @@ const {
   validateMemberRoleBody,
   validateUpdateUsersNicknameStatusBody,
   validateLazyLoadingParams,
+  validateGroupRoleUpdateBody,
 } = require("../middlewares/validators/discordactions");
 const checkIsVerifiedDiscord = require("../middlewares/verifydiscord");
 const checkCanGenerateDiscordLink = require("../middlewares/checkCanGenerateDiscordLink");
@@ -37,6 +39,14 @@ const router = express.Router();
 router.post("/groups", authenticate, checkIsVerifiedDiscord, validateGroupRoleBody, createGroupRole);
 router.get("/groups", authenticate, checkIsVerifiedDiscord, validateLazyLoadingParams, getPaginatedAllGroupRoles);
 router.delete("/groups/:groupId", authenticate, checkIsVerifiedDiscord, authorizeRoles([SUPERUSER]), deleteGroupRole);
+router.patch(
+  "/groups/:groupId",
+  authenticate,
+  checkIsVerifiedDiscord,
+  authorizeRoles([SUPERUSER]),
+  validateGroupRoleUpdateBody,
+  updateGroupRoleDetails
+);
 router.post("/roles", authenticate, checkIsVerifiedDiscord, validateMemberRoleBody, addGroupRoleToMember);
 /**
  * Short-circuit the GET method for this endpoint

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -140,6 +140,26 @@ const deleteGroupRoleFromDiscord = async (roleId) => {
   }
 };
 
+const updateGroupRoleInDiscord = async (roleId, roleName, userData) => {
+  try {
+    const headers = generateCloudFlareHeaders(userData);
+    const response = await fetch(`${DISCORD_BASE_URL}/roles/${roleId}`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ rolename: roleName }),
+    });
+
+    if (response.status === 200) {
+      return { success: true };
+    }
+    const data = await response.json();
+    return { success: false, message: data.message };
+  } catch (err) {
+    logger.error("Error updating role on Discord", err);
+    return { success: false, message: "Internal server error" };
+  }
+};
+
 module.exports = {
   getDiscordMembers,
   getDiscordRoles,
@@ -148,4 +168,5 @@ module.exports = {
   removeRoleFromUser,
   setUserDiscordNickname,
   deleteGroupRoleFromDiscord,
+  updateGroupRoleInDiscord,
 };


### PR DESCRIPTION
## Summary
- add updateGroupRoleDetails controller to edit Discord group name/description
- validate group edit payload via middleware
- add PATCH route for groups
- update Discord service to update group role on Discord
- check for duplicate role names and handle prefix logic in group edits

## Testing
- `yarn lint` *(fails: Couldn't find node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_684349d64d4c83218cc0cacc1f414353